### PR TITLE
Fix pep517 builds

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = zipreport-lib
-version = attr: zipreport.__version__
+version = attr: zipreport.version.__version__
 url = https://github.com/zipreport/zipreport
 author = João Pinheiro
 description = Python HTML to PDF reporting engine


### PR DESCRIPTION
Hey, and thanks for this useful library!

Currently zipreport-lib will not build under PEP517, due to having a build requirement, and thus preventing installation with poetry, for example.

```bash
pip wheel --no-cache-dir --use-pep517 "zipreport-lib (==2.0.0)"
```
would result in 
```
...
AttributeError: zipreport has no attribute __version__
...
ModuleNotFoundError: No module named 'requests'
```
because version is pulled from `zipreport.__version__` and accessing it causes "requests" to be imported.

Perhaps proper `pyproject.toml` is in order, but this small change does the job.