### PR TITLE
Debug Improvements

### DIFF
--- a/zipreport/cli/command/debug.py
+++ b/zipreport/cli/command/debug.py
@@ -56,13 +56,12 @@ class DebugCommand(CliCommand):
         return True, host, port
 
     def load_module(self, path) -> Optional[Union[bool, Callable]]:
-        try:
-            module_path, cls_name = path.rsplit(".", 1)
+        module_path, cls_name = path.rsplit(".", 1)
+        if importlib.util.find_spec(module_path) is not None:
             module = importlib.import_module(module_path)
             # return class or None
             return getattr(module, cls_name, None)
-
-        except Exception as e:
+        else:
             # not found, return False
             return False
 
@@ -79,7 +78,7 @@ class DebugCommand(CliCommand):
                 spec.loader.exec_module(module)
                 cls = getattr(module, cls_name, None)
                 return cls
-        except Exception as e:
+        except FileNotFoundError:
             # not found, return False
             return False
 

--- a/zipreport/cli/debug/server.py
+++ b/zipreport/cli/debug/server.py
@@ -3,6 +3,7 @@ import mimetypes
 import posixpath
 import shutil
 import sys
+import traceback
 from functools import partial
 from urllib.parse import urlparse, urlsplit, unquote
 from pathlib import Path
@@ -109,7 +110,7 @@ class ReportFileHandler(BaseHTTPRequestHandler):
             return True, io.BytesIO()
 
         except Exception as e:
-            return False, self.error_500(str(e))
+            return False, self.error_500(str(e), info=traceback.format_exc())
 
     def do_GET(self):
         """
@@ -202,16 +203,17 @@ class ReportFileHandler(BaseHTTPRequestHandler):
         contents.seek(0)
         return contents
 
-    def error_500(self, item: str):
+    def error_500(self, item: str, info: str | None = None) -> io.BytesIO:
         """
         Generates a customized 500 response
         :param item: optional error message
+        :pram info: optional traceback
         :return: io.BytesIO
         """
         if item:
             response = (
-                "<html><body><h3>Internal Server Error: {}</h3></body></html>".format(
-                    item
+                "<html><body><h3>Internal Server Error: {}</h3><pre><code>{}</code></pre></body></html>".format(
+                    item, info or ""
                 )
             )
         else:


### PR DESCRIPTION
Hello!

Thanks for all the recent changes you made upon my requests; they've been very useful!
While using `zipreport debug` for some time, I've stumbled upon three issues that I would like to address with a PR:

## Global (non-relative) imports were not working for modules provided to `--wrapper`

If I had a file `env.py`:

```python
from zipreport.template import EnvironmentWrapper
from other import foo

class Wrapper(EnvironmentWrapper):
    pass
```

And a file `other.py`:

```python
foo = "bar"
```

Calling `zipreport debug --wrapper env.Wrapper report/` would fail, because `importlib` wouldn't know where to import `other` from. I've fixed this by temporarily amending `sys.path` with the module's parent folder. This should be safe, and honestly, I don't see other good ways to handle it.

## Errors from loaded wrappers were suppressed

Sort of related to the previous issue, if an exception occurred during the loading of the wrapper module, it would be suppressed, and instead, a generic "Error: could not find file" message would be shown to the user.

Now, this error should only appear when the module/file is really missing, allowing real errors to be displayed. I haven't wrapped these errors into prints with traceback because I feel it's okay for them to be shown as-is; it's debug mode anyway :)

## Traceback on the error 500

Unrelated to the above issues, when an exception happens during template execution, error 500 only contains the text but not the traceback. Traceback actually works quite well in Jinja as it allows seeing in which template file/filter/etc. the error occurred.

So I've added a traceback to the page.