### PR TITLE
Stability and quality-of-life changes

### DIFF
--- a/zipreport/cli/command/debug.py
+++ b/zipreport/cli/command/debug.py
@@ -72,9 +72,10 @@ class DebugCommand(CliCommand):
         if not fpath.exists() or not fpath.is_file():
             return False
         try:
-            with TempSysPath(fpath.parent):
+            with TempSysPath(fpath.parent.parent):
                 spec = importlib.util.spec_from_file_location(fname, fpath)
                 module = importlib.util.module_from_spec(spec)
+                module.__package__ = fpath.parent.stem
                 # sys.modules["_zipreport_wrapper_"] = module
                 spec.loader.exec_module(module)
                 cls = getattr(module, cls_name, None)

--- a/zipreport/cli/command/debug.py
+++ b/zipreport/cli/command/debug.py
@@ -2,6 +2,7 @@ import importlib, importlib.util
 import sys
 from argparse import ArgumentParser
 from pathlib import Path
+import threading
 from typing import Callable, Union, Optional
 
 from .base import CliCommand
@@ -137,12 +138,26 @@ class DebugCommand(CliCommand):
         return True
 
 class TempSysPath:
-    """Temporarily adjust sys.path to include a path."""
+    """
+    A context manager to temporarily add a directory to the system path.
+
+    This class allows you to temporarily add a specified directory to the 
+    beginning of the system path (`sys.path`). When the context is exited, 
+    the directory is removed from the system path.
+
+    Attributes:
+        path (str): The directory path to be added to the system path.
+    """
+    
+    _lock = threading.Lock()
+    
     def __init__(self, path: Path | str):
         self.path = str(path)
 
     def __enter__(self):
+        self._lock.acquire()
         sys.path.insert(0, self.path)
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         sys.path.pop(0)
+        self._lock.release()

--- a/zipreport/fileutils/zipfs.py
+++ b/zipreport/fileutils/zipfs.py
@@ -129,4 +129,4 @@ class ZipFs(FsInterface):
         :param path:
         :return:
         """
-        return str(path).lstrip(self._sep)
+        return str(path).replace("\\", self._sep).lstrip(self._sep)


### PR DESCRIPTION
Hey!

This PR has 3 small-ish changes:

1. Fixed `ZipFs` on Windows. Currently building report on Windows would result in an error, because windows path separators were used.
```python
zipfile.BadZipFile: File name in directory 'path\\file' and header b'path/file' differ.
```

2. `TempSysPath` better handles threaded context and acquires a lock before updating `sys.path`. This does not really matter for cli debug mode, but can be useful to those, who run debug mode from some other python app.

3. Imports in env wrapper can now be relative (e.g. `from . import filters`). This seems more convenient for someone using this file both in debug mode and in production code, compared to what I introduced before (#38).

## Summary by Sourcery

Fix ZipFs path separator issue on Windows, enhance TempSysPath with threading support, and allow relative imports in the environment wrapper for better usability.

Bug Fixes:
- Fix ZipFs on Windows by replacing Windows path separators with the correct format to prevent zipfile.BadZipFile errors.

Enhancements:
- Improve TempSysPath to handle threaded contexts by acquiring a lock before updating sys.path.
- Allow relative imports in the environment wrapper to enhance convenience for users in both debug and production modes.